### PR TITLE
Fixed game over server freeze while writing replay

### DIFF
--- a/server-script/main.js
+++ b/server-script/main.js
@@ -14,6 +14,7 @@ exports.SERVER_PASSWORD = '';
 exports.DEFAULT_LOBBY_NAME = '';
 exports.DEFAULT_GAME_TYPE = 'FreeForAll';
 exports.REPLAY_FILENAME = 'replay';
+exports.REPLAY_TIMEOUT = 10 * 60;
 
 var envMaxPlayersIndex = env.indexOf('--max-players');
 if (envMaxPlayersIndex != -1) {
@@ -43,6 +44,11 @@ var envReplayFilenameIndex = env.indexOf('--replay-filename');
 if (envReplayFilenameIndex != -1) {
     exports.REPLAY_FILENAME = env[envReplayFilenameIndex+1];
     console.log('Replay filename ' + exports.REPLAY_FILENAME);
+}
+
+var envReplayTimeoutIndex = env.indexOf('--replay-timeout');
+if (envReplayTimeoutIndex != -1) {
+    exports.REPLAY_TIMEOUT = parseInt(env[envReplayTimeoutIndex+1]);
 }
 
 function shutdownWhenEmpty() {

--- a/server-script/main.js
+++ b/server-script/main.js
@@ -39,9 +39,10 @@ if (envDefaultGameTypeIndex != -1) {
     exports.DEFAULT_GAME_TYPE = env[envDefaultGameTypeIndex+1];
 }
 
-var envReplayFilenameeIndex = env.indexOf('--replay-filename');
-if (envReplayFilenameeIndex != -1) {
-    exports.REPLAY_FILENAME = env[envReplayFilenameeIndex+1];
+var envReplayFilenameIndex = env.indexOf('--replay-filename');
+if (envReplayFilenameIndex != -1) {
+    exports.REPLAY_FILENAME = env[envReplayFilenameIndex+1];
+    console.log('Replay filename ' + exports.REPLAY_FILENAME);
 }
 
 function shutdownWhenEmpty() {

--- a/server-script/main.js
+++ b/server-script/main.js
@@ -13,6 +13,7 @@ exports.MAX_SPECTATORS = 3;
 exports.SERVER_PASSWORD = '';
 exports.DEFAULT_LOBBY_NAME = '';
 exports.DEFAULT_GAME_TYPE = 'FreeForAll';
+exports.REPLAY_FILENAME = 'replay';
 
 var envMaxPlayersIndex = env.indexOf('--max-players');
 if (envMaxPlayersIndex != -1) {
@@ -36,6 +37,11 @@ if (envDefaultLobbyNameIndex != -1) {
 var envDefaultGameTypeIndex = env.indexOf('--default-game-type');
 if (envDefaultGameTypeIndex != -1) {
     exports.DEFAULT_GAME_TYPE = env[envDefaultGameTypeIndex+1];
+}
+
+var envReplayFilenameeIndex = env.indexOf('--replay-filename');
+if (envReplayFilenameeIndex != -1) {
+    exports.REPLAY_FILENAME = env[envReplayFilenameeIndex+1];
 }
 
 function shutdownWhenEmpty() {
@@ -62,7 +68,7 @@ function shutdownWhenEmpty() {
     }, 1000);
 }
 
-function setState(newState) {
+function setState(newState /*, config, optional */) {
     console.log("Changing state from", curState.name, "to", newState.name);
 
     if (newState === curState)

--- a/server-script/main.js
+++ b/server-script/main.js
@@ -13,7 +13,7 @@ exports.MAX_SPECTATORS = 3;
 exports.SERVER_PASSWORD = '';
 exports.DEFAULT_LOBBY_NAME = '';
 exports.DEFAULT_GAME_TYPE = 'FreeForAll';
-exports.REPLAY_FILENAME = 'replay';
+exports.REPLAY_FILENAME = '';
 exports.REPLAY_TIMEOUT = 10 * 60;
 
 var envMaxPlayersIndex = env.indexOf('--max-players');

--- a/server-script/states/game_over.js
+++ b/server-script/states/game_over.js
@@ -88,7 +88,7 @@ exports.enter = function (game_over_data) {
         if (REPLAY_FILENAME) {
             var now = new Date();
             switch(REPLAY_FILENAME) {
-                case 'UTCTIMESTAMP': REPLAY_FILENAME = now.toISOString(); break;
+                case 'UTCTIMESTAMP': REPLAY_FILENAME = now.toISOString().replace(/(T|:)/g, '-'); break;
             }
             server.writeReplay(REPLAY_FILENAME, 'replay');
         } else {

--- a/server-script/states/game_over.js
+++ b/server-script/states/game_over.js
@@ -86,6 +86,10 @@ exports.enter = function (game_over_data) {
 
     var writeReplay = _.once(function() {
         if (REPLAY_FILENAME) {
+            var now = new Date();
+            switch(REPLAY_FILENAME) {
+                case 'UTCTIMESTAMP': REPLAY_FILENAME = now.toISOString(); break;
+            }
             server.writeReplay(REPLAY_FILENAME, 'replay');
         } else {
             server.writeReplay();

--- a/server-script/states/game_over.js
+++ b/server-script/states/game_over.js
@@ -88,7 +88,7 @@ exports.enter = function (game_over_data) {
         if (REPLAY_FILENAME) {
             var now = new Date();
             switch(REPLAY_FILENAME) {
-                case 'UTCTIMESTAMP': REPLAY_FILENAME = now.toISOString().replace(/(T|:)/g, '-'); break;
+                case 'UTCTIMESTAMP': REPLAY_FILENAME = now.toISOString().replace(/(T|:)/g, '-') + '-replay'; break;
             }
             server.writeReplay(REPLAY_FILENAME, 'replay');
         } else {

--- a/server-script/states/game_over.js
+++ b/server-script/states/game_over.js
@@ -81,7 +81,7 @@ exports.url = 'coui://ui/main/game/game_over/game_over.html';
 exports.enter = function (game_over_data) {
     var GAMEOVER_SHUTDOWN_TIMEOUT = 3600;
 
-    var writeReplay = _.once(function() { server.writeReplay(); });
+    var writeReplay = _.once(function() { server.writeReplay(main.REPLAY_FILENAME); });
 
     _.delay(function () {
         sim.paused = true;

--- a/server-script/states/ladder_lobby.js
+++ b/server-script/states/ladder_lobby.js
@@ -1047,6 +1047,11 @@ exports.enter = function (owner) {
         if (player.armyIndex === -1) /* make the player a spectator if there is no room */
             player.spectator = true;
 
+        client.message({
+            message_type: 'downloading_mod_data',
+            payload: server.getModsPayload()
+        });
+            
         debug_log('calling client.downloadModsFromServer');
         client.downloadModsFromServer();
 

--- a/server-script/states/load_save.js
+++ b/server-script/states/load_save.js
@@ -271,6 +271,14 @@ exports.enter = function (save_file_info) {
         {
             client_connected = true;
 
+            client.message({
+                message_type: 'downloading_mod_data',
+                payload: server.getModsPayload()
+            });
+
+            console.log('calling client.downloadModsFromServer');
+            client.downloadModsFromServer();
+
             if (replay_config && replay_config.files) {
                 client.message({
                     message_type: 'memory_files',

--- a/server-script/states/load_save.js
+++ b/server-script/states/load_save.js
@@ -271,14 +271,6 @@ exports.enter = function (save_file_info) {
         {
             client_connected = true;
 
-            client.message({
-                message_type: 'downloading_mod_data',
-                payload: server.getModsPayload()
-            });
-
-            console.log('calling client.downloadModsFromServer');
-            client.downloadModsFromServer();
-
             if (replay_config && replay_config.files) {
                 client.message({
                     message_type: 'memory_files',


### PR DESCRIPTION
- added downloading_mod_data client message once replay file is loaded
- added client.downloadModsFromServer once replay file is loaded
- fixed server freeze 30 seconds after game over while replay is being written which prevents chat, stats, review, etc
- removed writing of replay after 30 seconds
- added REPLAY_TIMEOUT defaulting to 10 minutes to main
- added --replay-timeout command line option to set REPLAY_TIMEOUT on custom servers
- added write replay after REPLAY_TIMEOUT seconds even if all clients not disconnected (allows enough time for chat, stats, review, etc)
- added REPLAY_FILENAME with default of empty for Uber servers
- added --replay-filename command line option to set REPLAY_FILENAME on custom and local servers
- changed game_over to use REPLAY_FILENAME if provided
- added UTCTIMESTAMP option for REPLAY_FILENAME to automatically name replays on custom servers
- TODO: fix server mods not mounted by client in replays
