### PR TITLE
Reworked load_save to support server mods in replays and saved game and fixed fix for can't join empty slot issue

### DIFF
--- a/server-script/states/lobby.js
+++ b/server-script/states/lobby.js
@@ -887,7 +887,7 @@ function LobbyModel(creator) {
 
 // if an ubernet player disconnected without leaving then send a message to host with game ticket so host can call ubernet removePlayerFromGame (fixes the can't join game with empty slots issue)
 
-                if (!hasStartedPlaying && disconnected && player.isUbernetUser && player.client_data.ticket) {
+                if (!hasStartedPlaying && disconnected && player.client.isUbernetUser && player.client_data.ticket) {
 console.log('ubernet player ' + player.client.name + ' disconnected from lobby without leaving');
                     var hostIndex = _.findIndex( server.clients, function(client) { return client.id == creatorId });
                     server.clients[hostIndex].message({


### PR DESCRIPTION
- fixed fix for can't join empty slot issue

Reworked load_save to support server mods in replays and saved games (first pass)
- reworked sequence of events to support server mods in replays and saved games:
  - wait for replay to fully load with server mods info
  - process replay config
  - wait for client to connect and send first heartbeat from replay_loading
  - send mods info to client
  - wait for send_mods request from client (allows client to mount missing companion mods)
  - send mods to client with downloadModsFromServer
  - wait for mod_data received
  - send any cooked files to memory mount
  - wait for memory_files_received
  - generate armies
  - create sim from replay
  - move to playing state
- added mods_info client message sent when replay is fully loaded and client sends heartbeat from replay_loading
- added send_mods handler when client is ready to download server mods and any cooked files
- added mod_data_received handler when server mods have been download and mounted on client
